### PR TITLE
Update repo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the "vscode-elixir-mix-formatter" extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-03-05
+- Fix repo links.
+
 ## [1.0.1] - 2022-01-24
 - Fix readme.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ ext install animus-coop.vscode-elixir-mix-formatter
 ---
 ## Release Notes
 
+## [1.0.2] - 2025-03-05
+- Fix repo links.
+
 ## [1.0.1] - 2022-01-24
 - Fix readme
 
-[Read the complete CHANGELOG](https://github.com/animus-coop/vscode-elixir-mix-formatter/blob/master/CHANGELOG.md)
+[Read the complete CHANGELOG](https://github.com/animus-coop/vscode-elixir-formatter/blob/master/CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "publisher": "animus-coop",
   "preview": true,
   "license": "SEE LICENSE IN /LICENSE",
-  "homepage": "https://github.com/animus-coop/vscode-elixir-mix-formatter/blob/main/README.md",
+  "homepage": "https://github.com/animus-coop/vscode-elixir-formatter/blob/main/README.md",
   "repository": {
     "type": "git",
-    "url": "https://github.com/animus-coop/vscode-elixir-mix-formatter.git"
+    "url": "https://github.com/animus-coop/vscode-elixir-formatter.git"
   },
   "bugs": {
-    "url": "https://github.com/animus-coop/vscode-elixir-mix-formatter/issues",
+    "url": "https://github.com/animus-coop/vscode-elixir-formatter/issues",
     "email": "manu@animus.com.ar"
   },
   "engines": {


### PR DESCRIPTION
Hi @animus-coop,
The VSCode Marketplace links to a repo that does not exist anymore. Looks like you might have renamed it?

<img width="1336" alt="Broken Links" src="https://github.com/user-attachments/assets/4ec0573b-4d5e-4714-ac02-45f6967d9070" />

According to the VSCode marketplace guide, these are taken from the package.json file: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#marketplace-integration

I've updated the links and readme.
